### PR TITLE
Update consent banner for TTDSG neutrality

### DIFF
--- a/apps/frontend/components/ConsentBanner.tsx
+++ b/apps/frontend/components/ConsentBanner.tsx
@@ -4,25 +4,25 @@ import React, { useState, useEffect, useRef, useCallback } from 'react';
 const translations = {
   de: {
     'consent.banner.title': 'Datenschutz-Einstellungen',
-    'consent.banner.description': 'Wir verwenden Cookies und ähnliche Technologien, um Ihnen die bestmögliche Nutzererfahrung zu bieten, unsere Website zu verbessern und relevante Inhalte anzuzeigen. Sie können Ihre Einstellungen jederzeit anpassen.',
+    'consent.banner.description': 'Diese Website nutzt Technologien zur Datenverarbeitung, um Funktionen bereitzustellen und die Nutzererfahrung zu verbessern. Sie können Ihre Einstellungen jederzeit anpassen oder die Datenverarbeitung ablehnen.',
     'consent.banner.acceptAll': 'Alle akzeptieren',
     'consent.banner.rejectAll': 'Alle ablehnen',
     'consent.banner.customize': 'Einstellungen anpassen',
     'consent.banner.privacy': 'Datenschutzerklärung',
-    'consent.banner.statusAccepted': 'Alle Cookies wurden akzeptiert',
-    'consent.banner.statusRejected': 'Alle Cookies wurden abgelehnt',
-    'consent.banner.statusCustomized': 'Cookie-Einstellungen wurden angepasst',
+    'consent.banner.statusAccepted': 'Datenverarbeitung wurde zugestimmt',
+    'consent.banner.statusRejected': 'Datenverarbeitung wurde abgelehnt',
+    'consent.banner.statusCustomized': 'Datenschutz-Einstellungen wurden angepasst',
   },
   en: {
     'consent.banner.title': 'Privacy Settings',
-    'consent.banner.description': 'We use cookies and similar technologies to provide you with the best user experience, improve our website and display relevant content. You can adjust your settings at any time.',
+    'consent.banner.description': 'This website uses data processing technologies to provide functionality and improve user experience. You can adjust your settings at any time or reject data processing.',
     'consent.banner.acceptAll': 'Accept All',
     'consent.banner.rejectAll': 'Reject All',
     'consent.banner.customize': 'Customize Settings',
     'consent.banner.privacy': 'Privacy Policy',
-    'consent.banner.statusAccepted': 'All cookies have been accepted',
-    'consent.banner.statusRejected': 'All cookies have been rejected',
-    'consent.banner.statusCustomized': 'Cookie settings have been customized',
+    'consent.banner.statusAccepted': 'Data processing has been accepted',
+    'consent.banner.statusRejected': 'Data processing has been rejected',
+    'consent.banner.statusCustomized': 'Privacy settings have been customized',
   }
 };
 
@@ -50,21 +50,40 @@ const ConsentBanner: React.FC<ConsentBannerProps> = ({
   const rejectButtonRef = useRef<HTMLButtonElement>(null);
   
   const t = useCallback((key: string): string => {
-    return translations[language]?.[key as keyof typeof translations[typeof language]] || key;
+    const langTranslations = translations[language];
+    if (!langTranslations) return key;
+    return (langTranslations as Record<string, string>)[key] || key;
   }, [language]);
+
+  const handleAcceptAll = useCallback(() => {
+    setAnnouncement(t('consent.banner.statusAccepted'));
+    setIsVisible(false);
+    onAcceptAll?.();
+  }, [onAcceptAll, t]);
+
+  const handleRejectAll = useCallback(() => {
+    setAnnouncement(t('consent.banner.statusRejected'));
+    setIsVisible(false);
+    onRejectAll?.();
+  }, [onRejectAll, t]);
 
   // Focus management for accessibility
   useEffect(() => {
     if (isVisible && bannerRef.current) {
-      // Focus the banner when it appears for screen readers
-      bannerRef.current.focus();
+      // Focus the reject button first for TTDSG compliance (neutral approach)
+      const focusTarget = rejectButtonRef.current || bannerRef.current;
+      focusTarget.focus();
+      
+      // Announce the banner appearance
+      setAnnouncement(t('consent.banner.title'));
     }
-  }, [isVisible]);
+  }, [isVisible, t]);
 
   // Handle keyboard navigation
   const handleKeyDown = useCallback((event: React.KeyboardEvent) => {
     if (event.key === 'Escape') {
       // ESC key should close the banner by rejecting all (TTDSG compliant)
+      event.preventDefault();
       handleRejectAll();
     } else if (event.key === 'Tab') {
       // Ensure focus stays within the banner
@@ -84,20 +103,15 @@ const ConsentBanner: React.FC<ConsentBannerProps> = ({
           firstElement.focus();
         }
       }
+    } else if (event.key === 'Enter' || event.key === ' ') {
+      // Handle enter/space on focused elements
+      const target = event.target as HTMLElement;
+      if (target.tagName === 'BUTTON') {
+        event.preventDefault();
+        target.click();
+      }
     }
-  }, []);
-
-  const handleAcceptAll = useCallback(() => {
-    setAnnouncement(t('consent.banner.statusAccepted'));
-    setIsVisible(false);
-    onAcceptAll?.();
-  }, [onAcceptAll, t]);
-
-  const handleRejectAll = useCallback(() => {
-    setAnnouncement(t('consent.banner.statusRejected'));
-    setIsVisible(false);
-    onRejectAll?.();
-  }, [onRejectAll, t]);
+  }, [handleRejectAll]);
 
   const handleCustomize = useCallback(() => {
     setAnnouncement(t('consent.banner.statusCustomized'));
@@ -135,6 +149,7 @@ const ConsentBanner: React.FC<ConsentBannerProps> = ({
       <div
         ref={bannerRef}
         role="dialog"
+        aria-modal="true"
         aria-labelledby="consent-banner-title"
         aria-describedby="consent-banner-description"
         tabIndex={-1}
@@ -147,7 +162,7 @@ const ConsentBanner: React.FC<ConsentBannerProps> = ({
         `}
         style={{
           // Ensure the banner is always visible and accessible
-          minHeight: '120px',
+          minHeight: '140px',
         }}
       >
         <div className="max-w-7xl mx-auto">
@@ -168,22 +183,23 @@ const ConsentBanner: React.FC<ConsentBannerProps> = ({
               </p>
             </div>
             
-            {/* Action buttons */}
+            {/* Action buttons - Equal prominence per TTDSG */}
             <div className="flex flex-col sm:flex-row gap-3 lg:ml-6">
-              {/* Equal prominence buttons as per TTDSG requirements */}
+              {/* Reject button - equal prominence and positioned first for TTDSG compliance */}
               <button
                 ref={rejectButtonRef}
                 onClick={handleRejectAll}
                 className="
-                  px-4 py-2 text-sm font-medium
-                  bg-gray-100 text-gray-900 
-                  border border-gray-300 rounded-md
-                  hover:bg-gray-200 focus:outline-none focus:ring-2 
-                  focus:ring-gray-500 focus:ring-offset-2
-                  transition-colors duration-200
-                  min-w-[120px]
+                  px-6 py-3 text-sm font-medium
+                  bg-white text-gray-900 
+                  border-2 border-gray-400 rounded-md
+                  hover:bg-gray-50 hover:border-gray-500
+                  focus:outline-none focus:ring-2 focus:ring-gray-500 focus:ring-offset-2
+                  transition-all duration-200
+                  min-w-[140px] order-1 sm:order-1
                 "
                 aria-describedby="consent-banner-description"
+                aria-label={`${t('consent.banner.rejectAll')} - ${t('consent.banner.description')}`}
               >
                 {t('consent.banner.rejectAll')}
               </button>
@@ -192,15 +208,16 @@ const ConsentBanner: React.FC<ConsentBannerProps> = ({
                 ref={acceptButtonRef}
                 onClick={handleAcceptAll}
                 className="
-                  px-4 py-2 text-sm font-medium
-                  bg-blue-600 text-white 
-                  border border-blue-600 rounded-md
-                  hover:bg-blue-700 focus:outline-none focus:ring-2 
-                  focus:ring-blue-500 focus:ring-offset-2
-                  transition-colors duration-200
-                  min-w-[120px]
+                  px-6 py-3 text-sm font-medium
+                  bg-white text-gray-900 
+                  border-2 border-gray-400 rounded-md
+                  hover:bg-gray-50 hover:border-gray-500
+                  focus:outline-none focus:ring-2 focus:ring-gray-500 focus:ring-offset-2
+                  transition-all duration-200
+                  min-w-[140px] order-2 sm:order-2
                 "
                 aria-describedby="consent-banner-description"
+                aria-label={`${t('consent.banner.acceptAll')} - ${t('consent.banner.description')}`}
               >
                 {t('consent.banner.acceptAll')}
               </button>
@@ -212,10 +229,13 @@ const ConsentBanner: React.FC<ConsentBannerProps> = ({
             <button
               onClick={handleCustomize}
               className="
-                text-sm text-blue-600 hover:text-blue-800 
-                focus:outline-none focus:underline
-                transition-colors duration-200
+                text-sm text-gray-700 hover:text-gray-900 
+                focus:outline-none focus:ring-2 focus:ring-gray-500 focus:ring-offset-2
+                underline hover:no-underline
+                transition-all duration-200
+                px-1 py-1 rounded-sm
               "
+              aria-label={`${t('consent.banner.customize')} - Öffnet detaillierte Einstellungen`}
             >
               {t('consent.banner.customize')}
             </button>
@@ -223,10 +243,13 @@ const ConsentBanner: React.FC<ConsentBannerProps> = ({
             <button
               onClick={handlePrivacyPolicy}
               className="
-                text-sm text-blue-600 hover:text-blue-800 
-                focus:outline-none focus:underline
-                transition-colors duration-200
+                text-sm text-gray-700 hover:text-gray-900 
+                focus:outline-none focus:ring-2 focus:ring-gray-500 focus:ring-offset-2
+                underline hover:no-underline
+                transition-all duration-200
+                px-1 py-1 rounded-sm
               "
+              aria-label={`${t('consent.banner.privacy')} - Öffnet Datenschutzerklärung in neuem Tab`}
             >
               {t('consent.banner.privacy')}
             </button>


### PR DESCRIPTION
Update the consent banner to be TTDSG-neutral by ensuring equal visual prominence for accept/reject, using vendor-neutral i18n texts, and improving accessibility.

---
<a href="https://cursor.com/background-agent?bcId=bc-413ded99-14dd-4cbf-b38d-3c8c59df62a3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-413ded99-14dd-4cbf-b38d-3c8c59df62a3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

